### PR TITLE
fix useSiteMetadata

### DIFF
--- a/src/utils/useSiteMetadata.js
+++ b/src/utils/useSiteMetadata.js
@@ -12,6 +12,7 @@ export default function useSiteMetadata() {
           social {
             github
             twitter
+            facebook
           }
         }
       }


### PR DESCRIPTION
fixed:

- useSiteMetadata now fetches `social.facebook`.